### PR TITLE
Fix setuptools error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup, find_packages
 import re
 
-with open('README.md') as f:
+with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
 version = ''
-with open('discordrpc/__init__.py') as f:
+with open('discordrpc/__init__.py', encoding='utf-8') as f:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE).group(1)
 
 if not version:


### PR DESCRIPTION
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 2381: character maps to <undefined>
```